### PR TITLE
Improved calculation performance of Norm

### DIFF
--- a/pkg/embedding/embutil/embutil.go
+++ b/pkg/embedding/embutil/embutil.go
@@ -21,7 +21,7 @@ import (
 func Norm(vec []float64) float64 {
 	var n float64
 	for _, v := range vec {
-		n += math.Pow(v, 2)
+		n += v * v
 	}
 	return math.Sqrt(n)
 }


### PR DESCRIPTION
Using math.pow for x^2 calculations is slower than multiplying x * x.

### Overview
